### PR TITLE
Fix docker login to use --password-stdin instead of -p

### DIFF
--- a/AzureIntegration/ArmInfrastructure.cs
+++ b/AzureIntegration/ArmInfrastructure.cs
@@ -1,0 +1,277 @@
+using Azure;
+using Azure.Core;
+using Azure.Identity;
+using Azure.Monitor.Query;
+using Azure.ResourceManager;
+using Azure.ResourceManager.AppContainers;
+using Azure.ResourceManager.AppContainers.Models;
+using Azure.ResourceManager.ApplicationInsights;
+using Azure.ResourceManager.ContainerRegistry;
+using Azure.ResourceManager.ContainerRegistry.Models;
+using Azure.ResourceManager.OperationalInsights;
+using Azure.ResourceManager.Resources;
+
+namespace AzureIntegration;
+
+internal class ArmInfrastructure : IInfrastructure
+{
+    private readonly ArmClient _armClient;
+    private readonly TokenCredential _credential;
+    private readonly AzureLocation _location;
+    private SubscriptionResource? _subscription;
+
+    internal static string SanitizeAcrName(string name)
+    {
+        string acrName = $"{name.ToLower().Replace("-", "")}acr";
+        return acrName.Length > 50 ? acrName[..50] : acrName;
+    }
+
+    internal ArmInfrastructure(TokenCredential credential, AzureLocation location)
+    {
+        _credential = credential;
+        _armClient = new ArmClient(credential);
+        _location = location;
+    }
+
+    internal async Task<SubscriptionResource> GetSubscriptionAsync()
+    {
+        if (_subscription == null)
+        {
+            try
+            {
+                _subscription = await _armClient.GetDefaultSubscriptionAsync();
+            }
+            catch (AuthenticationFailedException)
+            {
+                throw new AuthenticationFailedException("Invalid credentials provided. Please check your client ID, client secret, and tenant ID.");
+            }
+            catch (Exception ex) when (ex.InnerException is AuthenticationFailedException)
+            {
+                throw new AuthenticationFailedException("Invalid credentials provided. Please check your client ID, client secret, and tenant ID.");
+            }
+        }
+        return _subscription;
+    }
+
+    internal ArmClient GetArmClient() => _armClient;
+    internal TokenCredential GetCredential() => _credential;
+
+    internal async Task<ResourceGroupResource> GetResourceGroupResource(string name)
+    {
+        var subscription = await GetSubscriptionAsync();
+        return (await subscription.GetResourceGroups().GetAsync(name)).Value;
+    }
+
+    public async Task CreateResourceGroup(string name)
+    {
+        var subscription = await GetSubscriptionAsync();
+        var resourceGroupData = new ResourceGroupData(_location);
+        await subscription.GetResourceGroups().CreateOrUpdateAsync(WaitUntil.Completed, name, resourceGroupData);
+    }
+
+    public async Task DeleteResourceGroup(string name)
+    {
+        var subscription = await GetSubscriptionAsync();
+        var resourceGroup = (await subscription.GetResourceGroups().GetAsync(name)).Value;
+        await resourceGroup.DeleteAsync(WaitUntil.Completed);
+    }
+
+    internal async Task<bool> ResourceGroupExists(string name)
+    {
+        var subscription = await GetSubscriptionAsync();
+        return await subscription.GetResourceGroups().ExistsAsync(name);
+    }
+
+    public async Task<ContainerRegistryInfo> CreateContainerRegistry(string resourceGroupName, string registryName)
+    {
+        var resourceGroup = await GetResourceGroupResource(resourceGroupName);
+        DeploymentLogger.Log($"Creating Container Registry '{registryName}'...");
+
+        var acrData = new ContainerRegistryData(_location, new ContainerRegistrySku(ContainerRegistrySkuName.Basic))
+        {
+            IsAdminUserEnabled = true
+        };
+        var acr = await resourceGroup.GetContainerRegistries()
+            .CreateOrUpdateAsync(WaitUntil.Completed, registryName, acrData);
+
+        var credentials = await acr.Value.GetCredentialsAsync();
+        DeploymentLogger.Log($"Container Registry created: {acr.Value.Data.LoginServer}");
+
+        return new ContainerRegistryInfo(
+            acr.Value.Data.LoginServer,
+            credentials.Value.Username,
+            credentials.Value.Passwords.First().Value);
+    }
+
+    public async Task<ApplicationInsights> CreateApplicationInsights(string resourceGroupName, string name)
+    {
+        var resourceGroup = await GetResourceGroupResource(resourceGroupName);
+        var appInsightsData = new ApplicationInsightsComponentData(_location, "web")
+        {
+            Kind = "web"
+        };
+
+        var appInsights = await resourceGroup.GetApplicationInsightsComponents().CreateOrUpdateAsync(
+            WaitUntil.Completed, name, appInsightsData);
+
+        var workspaceResource = _armClient.GetOperationalInsightsWorkspaceResource(appInsights.Value.Data.WorkspaceResourceId!);
+        var workspace = await workspaceResource.GetAsync();
+
+        var workspaceId = workspace.Value.Data.CustomerId.ToString()!;
+        var logsQueryClient = new LogsQueryClient(_credential);
+
+        return new ApplicationInsights(workspaceId, logsQueryClient, appInsights.Value.Data.ConnectionString);
+    }
+
+    public async Task<string> CreateContainerAppsEnvironment(string resourceGroupName, string name)
+    {
+        var resourceGroup = await GetResourceGroupResource(resourceGroupName);
+        string environmentName = $"{name}-env";
+        DeploymentLogger.Log($"Creating Container Apps Environment '{environmentName}'...");
+
+        var environmentData = new ContainerAppManagedEnvironmentData(_location);
+        var environment = await resourceGroup.GetContainerAppManagedEnvironments()
+            .CreateOrUpdateAsync(WaitUntil.Completed, environmentName, environmentData);
+
+        DeploymentLogger.Log("Container Apps Environment created");
+        return environment.Value.Id.ToString();
+    }
+
+    public async Task<ContainerAppInfo> CreateContainerApp(
+        string resourceGroupName,
+        string environmentId,
+        ContainerRegistryInfo registry,
+        string name,
+        string imageName,
+        Dictionary<string, string>? environmentVariables,
+        ApplicationInsights applicationInsights,
+        string? managedIdentityResourceId)
+    {
+        var resourceGroup = await GetResourceGroupResource(resourceGroupName);
+        DeploymentLogger.Log($"Creating Container App '{name}'...");
+
+        var appiEnvVars = new Dictionary<string, string>
+        {
+            { "APPLICATIONINSIGHTS_CONNECTION_STRING", applicationInsights.ConnectionString }
+        };
+        var mergedEnvVars = environmentVariables == null
+            ? appiEnvVars
+            : appiEnvVars.Concat(environmentVariables).ToDictionary(k => k.Key, v => v.Value);
+
+        var container = new ContainerAppContainer
+        {
+            Name = name.ToLower(),
+            Image = imageName,
+            Resources = new AppContainerResources { Cpu = 0.5, Memory = "1Gi" }
+        };
+        container.Env.Add(new ContainerAppEnvironmentVariable
+        {
+            Name = "DEPLOYMENT_DATE",
+            Value = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ")
+        });
+        container.Env.Add(new ContainerAppEnvironmentVariable
+        {
+            Name = "ASPNETCORE_URLS",
+            Value = "http://+:8080"
+        });
+        foreach (var kvp in mergedEnvVars)
+        {
+            container.Env.Add(new ContainerAppEnvironmentVariable { Name = kvp.Key, Value = kvp.Value });
+        }
+
+        var containerAppData = new ContainerAppData(_location)
+        {
+            ManagedEnvironmentId = new ResourceIdentifier(environmentId),
+            Configuration = new ContainerAppConfiguration
+            {
+                Ingress = new ContainerAppIngressConfiguration
+                {
+                    External = true,
+                    TargetPort = 8080,
+                    Transport = ContainerAppIngressTransportMethod.Auto
+                },
+                Registries =
+                {
+                    new ContainerAppRegistryCredentials
+                    {
+                        Server = registry.LoginServer,
+                        Username = registry.Username,
+                        PasswordSecretRef = "acr-password"
+                    }
+                },
+                Secrets =
+                {
+                    new ContainerAppWritableSecret
+                    {
+                        Name = "acr-password",
+                        Value = registry.Password
+                    }
+                }
+            },
+            Template = new ContainerAppTemplate
+            {
+                Containers = { container },
+                Scale = new ContainerAppScale { MinReplicas = 1, MaxReplicas = 1 }
+            }
+        };
+
+        if (managedIdentityResourceId != null)
+        {
+            containerAppData.Identity = new Azure.ResourceManager.Models.ManagedServiceIdentity(
+                Azure.ResourceManager.Models.ManagedServiceIdentityType.UserAssigned);
+            containerAppData.Identity.UserAssignedIdentities.Add(
+                new ResourceIdentifier(managedIdentityResourceId),
+                new Azure.ResourceManager.Models.UserAssignedIdentity());
+        }
+
+        var containerApp = await resourceGroup.GetContainerApps()
+            .CreateOrUpdateAsync(WaitUntil.Completed, name, containerAppData);
+
+        string fqdn = containerApp.Value.Data.Configuration.Ingress.Fqdn;
+        DeploymentLogger.Log("Container App created, waiting for readiness...");
+
+        await WaitForContainerAppToBeReady(fqdn);
+
+        return new ContainerAppInfo(containerApp.Value.Data.Name, fqdn, resourceGroupName, applicationInsights);
+    }
+
+    private static async Task WaitForContainerAppToBeReady(string fqdn, int timeoutMinutes = 10, int intervalSeconds = 30)
+    {
+        string appUrl = $"https://{fqdn}";
+        var timeout = TimeSpan.FromMinutes(timeoutMinutes);
+        var interval = TimeSpan.FromSeconds(intervalSeconds);
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+
+        DeploymentLogger.Log($"Waiting for Container App at {appUrl}...");
+
+        using var httpClient = new HttpClient();
+        httpClient.Timeout = TimeSpan.FromSeconds(30);
+
+        while (stopwatch.Elapsed < timeout)
+        {
+            try
+            {
+                var response = await httpClient.GetAsync(appUrl);
+
+                if (response.IsSuccessStatusCode)
+                {
+                    DeploymentLogger.Log($"Container App ready (Status: {response.StatusCode})");
+                    return;
+                }
+
+                DeploymentLogger.Log($"Not ready yet (Status: {response.StatusCode})");
+            }
+            catch (Exception ex)
+            {
+                DeploymentLogger.Log($"Not ready yet ({ex.Message})");
+            }
+
+            if (stopwatch.Elapsed + interval < timeout)
+            {
+                await Task.Delay(interval);
+            }
+        }
+
+        throw new TimeoutException($"Container App at {appUrl} did not become ready within {timeoutMinutes} minutes");
+    }
+}

--- a/AzureIntegration/AzureCloud.cs
+++ b/AzureIntegration/AzureCloud.cs
@@ -21,9 +21,9 @@ namespace AzureIntegration;
 
 public class AzureCloud
 {
-    private readonly TokenCredential _azureCredentials;
-    private readonly ArmClient _armClient;
-    private SubscriptionResource _subscription;
+    private readonly ArmInfrastructure? _armInfrastructure;
+    private readonly IInfrastructure _infrastructure;
+    private readonly IDockerProcessRunner _dockerProcessRunner;
     public AzureLocation Location { get; }
 
     // Static lock and flag for MSBuild registration to ensure thread safety
@@ -39,51 +39,42 @@ public class AzureCloud
 
     public AzureCloud(TokenCredential credentials, AzureLocation? location = null)
     {
-        _azureCredentials = credentials;
-        _armClient = new ArmClient(_azureCredentials);
-        _subscription = null!;
+        Location = location ?? AzureLocation.WestEurope;
+        _armInfrastructure = new ArmInfrastructure(credentials, Location);
+        _infrastructure = _armInfrastructure;
+        _dockerProcessRunner = new ProcessDockerRunner();
+    }
+
+    internal AzureCloud(IInfrastructure infrastructure, IDockerProcessRunner dockerProcessRunner, AzureLocation? location = null)
+    {
+        _infrastructure = infrastructure;
+        _dockerProcessRunner = dockerProcessRunner;
         Location = location ?? AzureLocation.WestEurope;
     }
 
-    internal async Task<SubscriptionResource> GetSubscriptionAsync()
-    {
-        if (_subscription == null)
-        {
-            try
-            {
-                _subscription = await _armClient.GetDefaultSubscriptionAsync();
-            }
-            catch (AuthenticationFailedException)
-            {
-                throw new AuthenticationFailedException("Invalid credentials provided. Please check your client ID, client secret, and tenant ID.");
-            }
-            catch (Exception ex) when (ex.InnerException is AuthenticationFailedException)
-            {
-                throw new AuthenticationFailedException("Invalid credentials provided. Please check your client ID, client secret, and tenant ID.");
-            }
-        }
-        return _subscription;
-    }
+    private ArmInfrastructure RequireArm()
+        => _armInfrastructure ?? throw new InvalidOperationException("This operation requires Azure ARM credentials.");
+
+    internal Task<SubscriptionResource> GetSubscriptionAsync()
+        => RequireArm().GetSubscriptionAsync();
 
     public async Task<ResourceGroup> CreateResourceGroup(string name)
     {
-        var subscription = await GetSubscriptionAsync();
-        var resourceGroupData = new ResourceGroupData(Location);
-        var operationResult = await subscription.GetResourceGroups().CreateOrUpdateAsync(WaitUntil.Completed, name, resourceGroupData);
-        return new ResourceGroup(operationResult.Value, this);
+        var arm = RequireArm();
+        await arm.CreateResourceGroup(name);
+        var resource = await arm.GetResourceGroupResource(name);
+        return new ResourceGroup(resource, this);
     }
 
     public async Task DeleteResourceGroup(string name)
     {
-        var subscription = await GetSubscriptionAsync();
-        var resourceGroup = (await subscription.GetResourceGroups().GetAsync(name)).Value;
-        await resourceGroup.DeleteAsync(WaitUntil.Completed);
+        RequireArm();
+        await _infrastructure.DeleteResourceGroup(name);
     }
 
     public async Task<bool> ResourceGroupExists(string name)
     {
-        var subscription = await GetSubscriptionAsync();
-        return await subscription.GetResourceGroups().ExistsAsync(name);
+        return await RequireArm().ResourceGroupExists(name);
     }
 
     public async Task<AzureFunction> DeployAzureFunction(
@@ -205,17 +196,26 @@ public class AzureCloud
 
         (var buildContext, var projectDir) = ProjectPathResolver.GetBuildContextPaths(projectDirectory, workspaceRoot);
 
-        var resourceGroup = await CreateResourceGroup(name);
+        await _infrastructure.CreateResourceGroup(name);
 
         try
         {
-            var acr = await CreateContainerRegistry(resourceGroup, name);
+            var registry = await _infrastructure.CreateContainerRegistry(name, ArmInfrastructure.SanitizeAcrName(name));
 
-            string imageName = await BuildAndPushImage(projectDir, buildContext, acr, name, dockerBuildArguments);
+            await VerifyDockerAvailable(_dockerProcessRunner);
+            await DockerLogin(registry.LoginServer, registry.Username, registry.Password, _dockerProcessRunner);
 
-            var applicationInsights = await resourceGroup.CreateApplicationInsights(name);
-            var environment = await CreateContainerAppsEnvironment(resourceGroup, name);
-            var containerApp = await CreateContainerApp(resourceGroup, environment, acr, name, imageName, environmentVariables, applicationInsights, managedIdentityResourceId);
+            string imageTag = $"{registry.LoginServer}/{name.ToLower()}:latest";
+            string dockerfilePath = Path.GetRelativePath(buildContext.FullName, Path.Combine(projectDir.FullName, "Dockerfile"))
+                .Replace('\\', '/');
+            await DockerBuild(buildContext, imageTag, dockerfilePath, dockerBuildArguments, _dockerProcessRunner);
+            await DockerPush(imageTag, _dockerProcessRunner);
+
+            var applicationInsights = await _infrastructure.CreateApplicationInsights(name, name);
+            var environmentId = await _infrastructure.CreateContainerAppsEnvironment(name, name);
+            var containerAppInfo = await _infrastructure.CreateContainerApp(name, environmentId, registry, name, imageTag, environmentVariables, applicationInsights, managedIdentityResourceId);
+
+            var containerApp = new AzureContainerApp(containerAppInfo.Name, containerAppInfo.Fqdn, containerAppInfo.ResourceGroupName, this, containerAppInfo.ApplicationInsights);
 
             DeploymentLogger.Log($"Deployment complete: {containerApp.Url}");
             return containerApp;
@@ -223,343 +223,55 @@ public class AzureCloud
         catch (Exception ex)
         {
             DeploymentLogger.LogError($"Deployment failed: {ex.Message}. Cleaning up resources...");
-            await DeleteResourceGroup(name);
+            await _infrastructure.DeleteResourceGroup(name);
             throw;
         }
     }
 
-    private async Task<ContainerRegistryResource> CreateContainerRegistry(ResourceGroup resourceGroup, string name)
-    {
-        string acrName = SanitizeAcrName(name);
-        DeploymentLogger.Log($"Creating Container Registry '{acrName}'...");
-
-        var acrData = new ContainerRegistryData(Location, new ContainerRegistrySku(ContainerRegistrySkuName.Basic))
-        {
-            IsAdminUserEnabled = true
-        };
-        var acr = await resourceGroup.Resource.GetContainerRegistries()
-            .CreateOrUpdateAsync(WaitUntil.Completed, acrName, acrData);
-        
-        DeploymentLogger.Log($"Container Registry created: {acr.Value.Data.LoginServer}");
-        return acr.Value;
-    }
-
-    private static string SanitizeAcrName(string name)
-    {
-        string acrName = $"{name.ToLower().Replace("-", "")}acr";
-        return acrName.Length > 50 ? acrName[..50] : acrName;
-    }
-
-    private static async Task<string> BuildAndPushImage(DirectoryInfo projectDir, DirectoryInfo buildContext, ContainerRegistryResource acr, string name, Dictionary<string, string>? dockerBuildArguments)
-    {
-        var credentials = await acr.GetCredentialsAsync();
-        string loginServer = acr.Data.LoginServer;
-        string username = credentials.Value.Username;
-        string password = credentials.Value.Passwords.First().Value;
-
-        await BuildAndPushDockerImage(projectDir, buildContext, loginServer, username, password, name.ToLower(), dockerBuildArguments);
-        return $"{loginServer}/{name.ToLower()}:latest";
-    }
-
-    private static async Task BuildAndPushDockerImage(
-        DirectoryInfo projectDir,
-        DirectoryInfo buildContext,
-        string acrLoginServer,
-        string acrUsername,
-        string acrPassword,
-        string imageName,
-        Dictionary<string, string>? dockerBuildArguments)
-    {
-        await VerifyDockerAvailable();
-        await DockerLogin(acrLoginServer, acrUsername, acrPassword);
-
-        string imageTag = $"{acrLoginServer}/{imageName}:latest";
-        string dockerfilePath = Path.GetRelativePath(buildContext.FullName, Path.Combine(projectDir.FullName, "Dockerfile"))
-            .Replace('\\', '/');
-        await DockerBuild(buildContext, imageTag, dockerfilePath, dockerBuildArguments);
-        await DockerPush(imageTag);
-    }
-
-    private static async Task VerifyDockerAvailable()
+    private static async Task VerifyDockerAvailable(IDockerProcessRunner runner)
     {
         DeploymentLogger.Log("Verifying Docker availability...");
-        var process = new Process
-        {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = "docker",
-                Arguments = "version --format '{{.Server.Os}}'",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            }
-        };
-        process.Start();
-        string output = await process.StandardOutput.ReadToEndAsync();
-        await process.WaitForExitAsync();
-        
-        if (process.ExitCode != 0)
-        {
-            string error = await process.StandardError.ReadToEndAsync();
-            throw new Exception($"Docker is not available or not running: {error}");
-        }
-        DeploymentLogger.Log($"Docker available (OS: {output.Trim()})");
+        var result = await runner.RunAsync("version --format '{{.Server.Os}}'");
+        if (result.ExitCode != 0)
+            throw new Exception($"Docker is not available or not running: {result.StdErr}");
+        DeploymentLogger.Log($"Docker available (OS: {result.StdOut.Trim()})");
     }
 
-    private static async Task DockerLogin(string server, string username, string password)
+    private static async Task DockerLogin(string server, string username, string password, IDockerProcessRunner runner)
     {
         DeploymentLogger.Log($"Logging into ACR {server}...");
-        var process = new Process
-        {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = "docker",
-                Arguments = $"login {server} -u {username} -p {password}",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            }
-        };
-        process.Start();
-        string error = await process.StandardError.ReadToEndAsync();
-        await process.WaitForExitAsync();
-        
-        if (process.ExitCode != 0)
-        {
-            throw new Exception($"Docker login failed: {error}");
-        }
+        var result = await runner.RunAsync($"login {server} -u {username} --password-stdin", stdinInput: password);
+        if (result.ExitCode != 0)
+            throw new Exception($"Docker login failed: {result.StdErr}");
         DeploymentLogger.Log("Docker login successful");
     }
 
-    private static async Task DockerBuild(DirectoryInfo buildContext, string imageTag, string dockerfilePath, Dictionary<string, string>? dockerBuildArguments)
+    private static async Task DockerBuild(DirectoryInfo buildContext, string imageTag, string dockerfilePath, Dictionary<string, string>? dockerBuildArguments, IDockerProcessRunner runner)
     {
         DeploymentLogger.Log($"Building Docker image {imageTag}...");
         string buildArgsString = dockerBuildArguments is { Count: > 0 }
             ? string.Join(" ", dockerBuildArguments.Select(a => $"--build-arg {a.Key}={a.Value}"))
             : string.Empty;
-        var process = new Process
+        var result = await runner.RunAsync($"build --platform linux/amd64 -t {imageTag} -f {dockerfilePath} {buildArgsString} .", workingDirectory: buildContext.FullName);
+        if (result.ExitCode != 0)
         {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = "docker",
-                Arguments = $"build --platform linux/amd64 -t {imageTag} -f {dockerfilePath} {buildArgsString} .",
-                WorkingDirectory = buildContext.FullName,
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            }
-        };
-        process.Start();
-        
-        var errorTask = process.StandardError.ReadToEndAsync();
-        await process.WaitForExitAsync();
-        string error = await errorTask;
-        
-        if (process.ExitCode != 0)
-        {
-            DeploymentLogger.LogError($"Docker build failed: {error}");
-            throw new Exception($"Docker build failed with exit code {process.ExitCode}: {error}");
+            DeploymentLogger.LogError($"Docker build failed: {result.StdErr}");
+            throw new Exception($"Docker build failed with exit code {result.ExitCode}: {result.StdErr}");
         }
         DeploymentLogger.Log("Docker build completed");
     }
 
-    private static async Task DockerPush(string imageTag)
+    private static async Task DockerPush(string imageTag, IDockerProcessRunner runner)
     {
         DeploymentLogger.Log("Pushing Docker image...");
-        var process = new Process
+        var result = await runner.RunAsync($"push {imageTag}");
+        if (result.ExitCode != 0)
         {
-            StartInfo = new ProcessStartInfo
-            {
-                FileName = "docker",
-                Arguments = $"push {imageTag}",
-                RedirectStandardOutput = true,
-                RedirectStandardError = true,
-                UseShellExecute = false,
-                CreateNoWindow = true
-            }
-        };
-        process.Start();
-        
-        var errorTask = process.StandardError.ReadToEndAsync();
-        await process.WaitForExitAsync();
-        string error = await errorTask;
-        
-        if (process.ExitCode != 0)
-        {
-            DeploymentLogger.LogError($"Docker push failed: {error}");
-            throw new Exception($"Docker push failed with exit code {process.ExitCode}: {error}");
+            DeploymentLogger.LogError($"Docker push failed: {result.StdErr}");
+            throw new Exception($"Docker push failed with exit code {result.ExitCode}: {result.StdErr}");
         }
         DeploymentLogger.Log("Docker image pushed successfully");
     }
-
-    private static ContainerAppContainer BuildContainer(
-        string name, 
-        string imageName, 
-        Dictionary<string, string>? environmentVariables)
-    {
-        var container = new ContainerAppContainer
-        {
-            Name = name.ToLower(),
-            Image = imageName,
-            Resources = new AppContainerResources { Cpu = 0.5, Memory = "1Gi" }
-        };
-
-        container.Env.Add(new ContainerAppEnvironmentVariable 
-        { 
-            Name = "DEPLOYMENT_DATE", 
-            Value = DateTime.UtcNow.ToString("yyyy-MM-ddTHH:mm:ssZ") 
-        });
-        container.Env.Add(new ContainerAppEnvironmentVariable 
-        { 
-            Name = "ASPNETCORE_URLS", 
-            Value = "http://+:8080" 
-        });
-
-        if (environmentVariables != null)
-        {
-            foreach (var kvp in environmentVariables)
-            {
-                container.Env.Add(new ContainerAppEnvironmentVariable { Name = kvp.Key, Value = kvp.Value });
-            }
-        }
-
-        return container;
-    }
-
-    private async Task<ContainerAppManagedEnvironmentResource> CreateContainerAppsEnvironment(ResourceGroup resourceGroup, string name)
-    {
-        string environmentName = $"{name}-env";
-        DeploymentLogger.Log($"Creating Container Apps Environment '{environmentName}'...");
-        
-        var environmentData = new ContainerAppManagedEnvironmentData(Location);
-        var environment = await resourceGroup.Resource.GetContainerAppManagedEnvironments()
-            .CreateOrUpdateAsync(WaitUntil.Completed, environmentName, environmentData);
-
-        DeploymentLogger.Log("Container Apps Environment created");
-        return environment.Value;
-    }
-
-    private async Task<AzureContainerApp> CreateContainerApp(
-        ResourceGroup resourceGroup,
-        ContainerAppManagedEnvironmentResource environment,
-        ContainerRegistryResource acr,
-        string name,
-        string imageName,
-        Dictionary<string, string>? environmentVariables,
-        ApplicationInsights applicationInsights,
-        string? managedIdentityResourceId = null)
-    {
-        DeploymentLogger.Log($"Creating Container App '{name}'...");
-
-        var credentials = await acr.GetCredentialsAsync();
-        var appiEnvVars = new Dictionary<string, string>
-        {
-            { "APPLICATIONINSIGHTS_CONNECTION_STRING", applicationInsights.ConnectionString }
-        };
-        var mergedEnvVars = environmentVariables == null
-            ? appiEnvVars
-            : appiEnvVars.Concat(environmentVariables).ToDictionary(k => k.Key, v => v.Value);
-        var container = BuildContainer(name, imageName, mergedEnvVars);
-        
-        var containerAppData = new ContainerAppData(Location)
-        {
-            ManagedEnvironmentId = environment.Id,
-            Configuration = new ContainerAppConfiguration
-            {
-                Ingress = new ContainerAppIngressConfiguration
-                {
-                    External = true,
-                    TargetPort = 8080,
-                    Transport = ContainerAppIngressTransportMethod.Auto
-                },
-                Registries =
-                {
-                    new ContainerAppRegistryCredentials
-                    {
-                        Server = acr.Data.LoginServer,
-                        Username = credentials.Value.Username,
-                        PasswordSecretRef = "acr-password"
-                    }
-                },
-                Secrets =
-                {
-                    new ContainerAppWritableSecret 
-                    { 
-                        Name = "acr-password", 
-                        Value = credentials.Value.Passwords.First().Value 
-                    }
-                }
-            },
-            Template = new ContainerAppTemplate
-            {
-                Containers = { container },
-                Scale = new ContainerAppScale { MinReplicas = 1, MaxReplicas = 1 }
-            }
-        };
-
-        if (managedIdentityResourceId != null)
-        {
-            containerAppData.Identity = new Azure.ResourceManager.Models.ManagedServiceIdentity(
-                Azure.ResourceManager.Models.ManagedServiceIdentityType.UserAssigned);
-            containerAppData.Identity.UserAssignedIdentities.Add(
-                new ResourceIdentifier(managedIdentityResourceId),
-                new Azure.ResourceManager.Models.UserAssignedIdentity());
-        }
-
-        var containerApp = await resourceGroup.Resource.GetContainerApps()
-            .CreateOrUpdateAsync(WaitUntil.Completed, name, containerAppData);
-
-        string fqdn = containerApp.Value.Data.Configuration.Ingress.Fqdn;
-        DeploymentLogger.Log("Container App created, waiting for readiness...");
-        
-        await WaitForContainerAppToBeReady(fqdn);
-
-        return new AzureContainerApp(containerApp.Value.Data.Name, fqdn, resourceGroup.Resource.Data.Name, this, applicationInsights);
-    }
-
-    private static async Task WaitForContainerAppToBeReady(string fqdn, int timeoutMinutes = 10, int intervalSeconds = 30)
-    {
-        string appUrl = $"https://{fqdn}";
-        var timeout = TimeSpan.FromMinutes(timeoutMinutes);
-        var interval = TimeSpan.FromSeconds(intervalSeconds);
-        var stopwatch = Stopwatch.StartNew();
-
-        DeploymentLogger.Log($"Waiting for Container App at {appUrl}...");
-
-        using var httpClient = new HttpClient();
-        httpClient.Timeout = TimeSpan.FromSeconds(30);
-
-        while (stopwatch.Elapsed < timeout)
-        {
-            try
-            {
-                var response = await httpClient.GetAsync(appUrl);
-
-                if (response.IsSuccessStatusCode)
-                {
-                    DeploymentLogger.Log($"Container App ready (Status: {response.StatusCode})");
-                    return;
-                }
-
-                DeploymentLogger.Log($"Not ready yet (Status: {response.StatusCode})");
-            }
-            catch (Exception ex)
-            {
-                DeploymentLogger.Log($"Not ready yet ({ex.Message})");
-            }
-
-            if (stopwatch.Elapsed + interval < timeout)
-            {
-                await Task.Delay(interval);
-            }
-        }
-
-        throw new TimeoutException($"Container App at {appUrl} did not become ready within {timeoutMinutes} minutes");
-    }
-
 
     private async Task DeployZipFile(string zipFilePath, string serviceName)
     {
@@ -571,7 +283,7 @@ public class AzureCloud
         await using var fileStream = new FileStream(zipFilePath, FileMode.Open, FileAccess.Read);
         using var content = new StreamContent(fileStream);
         content.Headers.ContentType = new MediaTypeHeaderValue("application/zip");
-        var accessToken = await _azureCredentials.GetTokenAsync(new TokenRequestContext(["https://management.azure.com/.default"]), CancellationToken.None);
+        var accessToken = await RequireArm().GetCredential().GetTokenAsync(new TokenRequestContext(["https://management.azure.com/.default"]), CancellationToken.None);
         httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", accessToken.Token);
 
         Console.WriteLine($"Deploying zip file to {serviceName}...");
@@ -755,7 +467,8 @@ public class AzureCloud
 
     public async Task<IEnumerable<ResourceGroup>> GetResourceGroups()
     {
-        var subscription = await GetSubscriptionAsync();
+        var arm = RequireArm();
+        var subscription = await arm.GetSubscriptionAsync();
         var resourceGroups = new List<ResourceGroup>();
         await foreach (var resourceGroup in subscription.GetResourceGroups().GetAllAsync())
         {
@@ -767,11 +480,11 @@ public class AzureCloud
 
     public ArmClient GetArmClient()
     {
-        return _armClient;
+        return RequireArm().GetArmClient();
     }
 
     public TokenCredential GetCredential()
     {
-        return _azureCredentials;
+        return RequireArm().GetCredential();
     }
 }

--- a/AzureIntegration/AzureIntegration.csproj
+++ b/AzureIntegration/AzureIntegration.csproj
@@ -7,7 +7,7 @@
     
     <!-- NuGet Package Properties -->
     <PackageId>AzureForHumans</PackageId>
-    <PackageVersion>0.10.0</PackageVersion>
+    <PackageVersion>0.10.1</PackageVersion>
     <Authors>Javier Asensio Montiel; Víctor Calatayud Asensio</Authors>
     <Description>A human-friendly wrapper for Azure SDK that simplifies common Azure operations like deploying Azure Functions, managing resource groups, and working with storage accounts.</Description>
     <PackageTags>Azure;SDK;Functions;Storage;ResourceGroups;Cloud</PackageTags>

--- a/AzureIntegration/IDockerProcessRunner.cs
+++ b/AzureIntegration/IDockerProcessRunner.cs
@@ -1,0 +1,8 @@
+namespace AzureIntegration;
+
+internal interface IDockerProcessRunner
+{
+    Task<DockerResult> RunAsync(string arguments, string? stdinInput = null, string? workingDirectory = null);
+}
+
+internal record DockerResult(int ExitCode, string StdOut, string StdErr);

--- a/AzureIntegration/IInfrastructure.cs
+++ b/AzureIntegration/IInfrastructure.cs
@@ -1,0 +1,23 @@
+namespace AzureIntegration;
+
+internal record ContainerRegistryInfo(string LoginServer, string Username, string Password);
+
+internal record ContainerAppInfo(string Name, string Fqdn, string ResourceGroupName, ApplicationInsights ApplicationInsights);
+
+internal interface IInfrastructure
+{
+    Task CreateResourceGroup(string name);
+    Task DeleteResourceGroup(string name);
+    Task<ContainerRegistryInfo> CreateContainerRegistry(string resourceGroupName, string registryName);
+    Task<ApplicationInsights> CreateApplicationInsights(string resourceGroupName, string name);
+    Task<string> CreateContainerAppsEnvironment(string resourceGroupName, string name);
+    Task<ContainerAppInfo> CreateContainerApp(
+        string resourceGroupName,
+        string environmentId,
+        ContainerRegistryInfo registry,
+        string name,
+        string imageName,
+        Dictionary<string, string>? environmentVariables,
+        ApplicationInsights applicationInsights,
+        string? managedIdentityResourceId);
+}

--- a/AzureIntegration/ProcessDockerRunner.cs
+++ b/AzureIntegration/ProcessDockerRunner.cs
@@ -1,0 +1,40 @@
+using System.Diagnostics;
+
+namespace AzureIntegration;
+
+internal class ProcessDockerRunner : IDockerProcessRunner
+{
+    public async Task<DockerResult> RunAsync(string arguments, string? stdinInput = null, string? workingDirectory = null)
+    {
+        var process = new Process
+        {
+            StartInfo = new ProcessStartInfo
+            {
+                FileName = "docker",
+                Arguments = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true,
+                RedirectStandardInput = stdinInput != null,
+                UseShellExecute = false,
+                CreateNoWindow = true
+            }
+        };
+
+        if (workingDirectory != null)
+            process.StartInfo.WorkingDirectory = workingDirectory;
+
+        process.Start();
+
+        if (stdinInput != null)
+        {
+            await process.StandardInput.WriteAsync(stdinInput);
+            process.StandardInput.Close();
+        }
+
+        string stdOut = await process.StandardOutput.ReadToEndAsync();
+        string stdErr = await process.StandardError.ReadToEndAsync();
+        await process.WaitForExitAsync();
+
+        return new DockerResult(process.ExitCode, stdOut, stdErr);
+    }
+}

--- a/AzureTests/ContainerAppDeploymentTests.cs
+++ b/AzureTests/ContainerAppDeploymentTests.cs
@@ -4,38 +4,31 @@ namespace AzureTests;
 
 public class ContainerAppDeploymentTests
 {
-    [Test]
-    public async Task Deploy_DoesNotExposePasswordInDockerCommandLineArguments()
+    private readonly InMemoryInfrastructure _infrastructure = new();
+    private readonly DockerProcessSpy _docker = new();
+
+    [SetUp]
+    public async Task DeployContainerApp()
     {
-        var docker = new DockerProcessSpy();
         var azure = new AzureCloud(
-            infrastructure: new InMemoryInfrastructure(),
-            dockerProcessRunner: docker);
+            infrastructure: _infrastructure,
+            dockerProcessRunner: _docker);
 
         await azure.DeployContainerApp(
             projectDirectory: "TestContainerApp",
             name: "my-app");
-
-        var loginCall = docker.Calls.First(c => c.Arguments.Contains("login"));
-        Assert.That(loginCall.Arguments, Does.Not.Contain(InMemoryInfrastructure.AcrPassword),
-            "Password must not appear in CLI arguments to prevent exposure in process list or logs");
     }
 
     [Test]
-    public async Task Deploy_SendsPasswordViaStandardInput()
+    public void RegistryPassword_IsNotExposedInCommandLineArguments()
     {
-        var docker = new DockerProcessSpy();
-        var azure = new AzureCloud(
-            infrastructure: new InMemoryInfrastructure(),
-            dockerProcessRunner: docker);
+        Assert.That(_docker.LoginCall.Arguments, Does.Not.Contain(_infrastructure.RegistryPassword));
+    }
 
-        await azure.DeployContainerApp(
-            projectDirectory: "TestContainerApp",
-            name: "my-app");
-
-        var loginCall = docker.Calls.First(c => c.Arguments.Contains("login"));
-        Assert.That(loginCall.StdinInput, Is.EqualTo(InMemoryInfrastructure.AcrPassword),
-            "Password should be sent via stdin using --password-stdin");
+    [Test]
+    public void RegistryPassword_IsSentViaStandardInput()
+    {
+        Assert.That(_docker.LoginCall.StdinInput, Is.EqualTo(_infrastructure.RegistryPassword));
     }
 }
 
@@ -44,6 +37,7 @@ internal record DockerProcessCall(string Arguments, string? StdinInput, string? 
 internal class DockerProcessSpy : IDockerProcessRunner
 {
     public List<DockerProcessCall> Calls { get; } = new();
+    public DockerProcessCall LoginCall => Calls.First(c => c.Arguments.Contains("login"));
 
     public Task<DockerResult> RunAsync(string arguments, string? stdinInput = null, string? workingDirectory = null)
     {

--- a/AzureTests/ContainerAppDeploymentTests.cs
+++ b/AzureTests/ContainerAppDeploymentTests.cs
@@ -1,0 +1,53 @@
+using AzureIntegration;
+
+namespace AzureTests;
+
+public class ContainerAppDeploymentTests
+{
+    [Test]
+    public async Task Deploy_DoesNotExposePasswordInDockerCommandLineArguments()
+    {
+        var docker = new DockerProcessSpy();
+        var azure = new AzureCloud(
+            infrastructure: new InMemoryInfrastructure(),
+            dockerProcessRunner: docker);
+
+        await azure.DeployContainerApp(
+            projectDirectory: "TestContainerApp",
+            name: "my-app");
+
+        var loginCall = docker.Calls.First(c => c.Arguments.Contains("login"));
+        Assert.That(loginCall.Arguments, Does.Not.Contain(InMemoryInfrastructure.AcrPassword),
+            "Password must not appear in CLI arguments to prevent exposure in process list or logs");
+    }
+
+    [Test]
+    public async Task Deploy_SendsPasswordViaStandardInput()
+    {
+        var docker = new DockerProcessSpy();
+        var azure = new AzureCloud(
+            infrastructure: new InMemoryInfrastructure(),
+            dockerProcessRunner: docker);
+
+        await azure.DeployContainerApp(
+            projectDirectory: "TestContainerApp",
+            name: "my-app");
+
+        var loginCall = docker.Calls.First(c => c.Arguments.Contains("login"));
+        Assert.That(loginCall.StdinInput, Is.EqualTo(InMemoryInfrastructure.AcrPassword),
+            "Password should be sent via stdin using --password-stdin");
+    }
+}
+
+internal record DockerProcessCall(string Arguments, string? StdinInput, string? WorkingDirectory);
+
+internal class DockerProcessSpy : IDockerProcessRunner
+{
+    public List<DockerProcessCall> Calls { get; } = new();
+
+    public Task<DockerResult> RunAsync(string arguments, string? stdinInput = null, string? workingDirectory = null)
+    {
+        Calls.Add(new DockerProcessCall(arguments, stdinInput, workingDirectory));
+        return Task.FromResult(new DockerResult(0, "", ""));
+    }
+}

--- a/AzureTests/InMemoryInfrastructure.cs
+++ b/AzureTests/InMemoryInfrastructure.cs
@@ -1,0 +1,63 @@
+using Azure.Monitor.Query;
+using AzureIntegration;
+
+namespace AzureTests;
+
+internal class InMemoryInfrastructure : IInfrastructure
+{
+    public const string AcrPassword = "fake-acr-password-s3cr3t";
+    private const string AcrLoginServer = "fakeregistry.azurecr.io";
+    private const string AcrUsername = "fakeuser";
+
+    public List<string> CreatedResourceGroups { get; } = new();
+    public List<string> DeletedResourceGroups { get; } = new();
+
+    public Task CreateResourceGroup(string name)
+    {
+        CreatedResourceGroups.Add(name);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteResourceGroup(string name)
+    {
+        DeletedResourceGroups.Add(name);
+        return Task.CompletedTask;
+    }
+
+    public Task<ContainerRegistryInfo> CreateContainerRegistry(string resourceGroupName, string registryName)
+    {
+        return Task.FromResult(new ContainerRegistryInfo(AcrLoginServer, AcrUsername, AcrPassword));
+    }
+
+    public Task<ApplicationInsights> CreateApplicationInsights(string resourceGroupName, string name)
+    {
+        return Task.FromResult(new ApplicationInsights("fake-workspace-id", new LogsQueryClient(new FakeCredential()), "InstrumentationKey=fake"));
+    }
+
+    public Task<string> CreateContainerAppsEnvironment(string resourceGroupName, string name)
+    {
+        return Task.FromResult($"/subscriptions/fake/resourceGroups/{resourceGroupName}/providers/Microsoft.App/managedEnvironments/{name}-env");
+    }
+
+    public Task<ContainerAppInfo> CreateContainerApp(
+        string resourceGroupName,
+        string environmentId,
+        ContainerRegistryInfo registry,
+        string name,
+        string imageName,
+        Dictionary<string, string>? environmentVariables,
+        ApplicationInsights applicationInsights,
+        string? managedIdentityResourceId)
+    {
+        return Task.FromResult(new ContainerAppInfo(name, $"{name}.azurecontainerapps.io", resourceGroupName, applicationInsights));
+    }
+}
+
+internal class FakeCredential : Azure.Core.TokenCredential
+{
+    public override Azure.Core.AccessToken GetToken(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken)
+        => new("fake-token", DateTimeOffset.MaxValue);
+
+    public override ValueTask<Azure.Core.AccessToken> GetTokenAsync(Azure.Core.TokenRequestContext requestContext, System.Threading.CancellationToken cancellationToken)
+        => ValueTask.FromResult(new Azure.Core.AccessToken("fake-token", DateTimeOffset.MaxValue));
+}

--- a/AzureTests/InMemoryInfrastructure.cs
+++ b/AzureTests/InMemoryInfrastructure.cs
@@ -5,7 +5,7 @@ namespace AzureTests;
 
 internal class InMemoryInfrastructure : IInfrastructure
 {
-    public const string AcrPassword = "fake-acr-password-s3cr3t";
+    public string RegistryPassword { get; } = "fake-acr-password-s3cr3t";
     private const string AcrLoginServer = "fakeregistry.azurecr.io";
     private const string AcrUsername = "fakeuser";
 
@@ -26,7 +26,7 @@ internal class InMemoryInfrastructure : IInfrastructure
 
     public Task<ContainerRegistryInfo> CreateContainerRegistry(string resourceGroupName, string registryName)
     {
-        return Task.FromResult(new ContainerRegistryInfo(AcrLoginServer, AcrUsername, AcrPassword));
+        return Task.FromResult(new ContainerRegistryInfo(AcrLoginServer, AcrUsername, RegistryPassword));
     }
 
     public Task<ApplicationInsights> CreateApplicationInsights(string resourceGroupName, string name)


### PR DESCRIPTION
- Extract IInfrastructure and ArmInfrastructure from AzureCloud
- Extract IDockerProcessRunner and ProcessDockerRunner for docker process calls
- Use --password-stdin to avoid exposing password in CLI arguments
- Single code path in DeployContainerApp for both real and test execution
- Add InMemoryInfrastructure and DockerProcessSpy for testing
- Add tests verifying password is not in CLI args and is sent via stdin